### PR TITLE
Set up jest contexts and test Navbar component

### DIFF
--- a/__tests__/Navbar.test.tsx
+++ b/__tests__/Navbar.test.tsx
@@ -1,0 +1,39 @@
+import { screen, within } from "@testing-library/react";
+import { renderWithContexts } from "../test-utils/render";
+import { Navbar } from "../components/common/Navbar";
+import { SITE_NAME } from "../config/config";
+
+const getHomeLinkByRole = () => {
+  return screen.getByRole("link", { name: /go to home page/i });
+};
+
+describe("link to home page", () => {
+  test("exists in Navbar", () => {
+    renderWithContexts(<Navbar />);
+
+    const linkToHome = getHomeLinkByRole();
+
+    expect(linkToHome).toBeInTheDocument();
+  });
+
+  test(`contains site name (${SITE_NAME}) as visible header text`, () => {
+    renderWithContexts(<Navbar />);
+
+    // sticking to lowercase throughout the app, so using a case sensitive search
+    const siteNameHeading = within(getHomeLinkByRole()).getByRole("heading", {
+      name: SITE_NAME,
+    });
+
+    expect(siteNameHeading).toBeInTheDocument();
+  });
+
+  test("contains logo as visible image", () => {
+    renderWithContexts(<Navbar />);
+
+    const logoImg = within(getHomeLinkByRole()).getByRole("img", {
+      name: /logo image/i,
+    });
+
+    expect(logoImg).toBeInTheDocument();
+  });
+});

--- a/components/common/LogoLink.tsx
+++ b/components/common/LogoLink.tsx
@@ -20,7 +20,7 @@ export const LogoLink = ({
   height = 40,
 }: Props) => {
   return (
-    <Link style={homeLinkStyle} href={href}>
+    <Link style={homeLinkStyle} href={href} aria-label="Go to home page">
       <Flex sx={logoFlexSx}>
         <Image src={src} alt={alt} width={width} height={height} />
         <Text sx={logoTextSx} component="h1">

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ const customJestConfig = {
   //   '@/(.*)$': '<rootDir>/src/$1',
   // },
   testEnvironment: "jest-environment-jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/lib/queryClient.ts
+++ b/lib/queryClient.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from "react-query";
+
+export const generateQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 120, // 2 hours
+        cacheTime: 1000 * 60 * 150, // 2.5 hours
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        refetchOnWindowFocus: false,
+        retry: false,
+      },
+    },
+  });
+};
+
+export const queryClient = generateQueryClient();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,11 +3,11 @@ import { Navbar } from "../components/common/Navbar";
 import type { AppProps } from "next/app";
 import { SITE_NAME } from "../config/config";
 import Head from "next/head";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
+import { queryClient } from "../lib/queryClient";
 
 export const cssCache = createEmotionCache({ key: "mantine" });
-export const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/test-utils/render.tsx
+++ b/test-utils/render.tsx
@@ -1,0 +1,29 @@
+import { MantineProvider } from "@mantine/core";
+import { render, RenderResult } from "@testing-library/react";
+import { ReactElement } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { generateQueryClient } from "../lib/queryClient";
+
+const generateTestQueryClient = () => {
+  const client = generateQueryClient();
+  const options = client.getDefaultOptions();
+  options.queries = { ...options.queries, retry: false };
+  return client;
+};
+
+// allow configuring context(s) when rendering components for a test
+type ContextsProps = {
+  queryClient?: QueryClient;
+};
+
+export const renderWithContexts = (
+  ui: ReactElement,
+  opts?: ContextsProps
+): RenderResult => {
+  const queryClient = opts?.queryClient ?? generateTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider>{ui}</MantineProvider>
+    </QueryClientProvider>
+  );
+};


### PR DESCRIPTION
I made a helper function called `renderWithContexts` in `test-utils/render.tsx`
The purpose is to easily render components in test files and automatically wrap them with their necessary dependencies such as React Query & Mantine's context providers.

3 tests were added for the Navbar component which show a simple example of using the `renderWithContexts` function.

As more contexts get introduced into the app (ex: AuthContextProvider), they will be included in the `renderWithContexts` function. `renderWithContexts` will provide sensible defaults to contexts, but will allow configuration in case a test requires customized settings. 

Ex: test a component that renders accordingly to values in an AuthContextProvider. Display user's name, etc.