### PR TITLE
Extract query key to an object method

### DIFF
--- a/hooks/api/useRecentTierList.ts
+++ b/hooks/api/useRecentTierList.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "react-query";
 import { TierList } from "../../lib/types/tierlist";
 import apiClient from "../../lib/apiClient";
+import { queryKeys } from "../../lib/queryKeys";
 
 async function fetchRecentTierLists() {
   const res = await apiClient.get<TierList[]>("/tierlist/recent");
@@ -9,7 +10,7 @@ async function fetchRecentTierLists() {
 
 export function useRecentTierList() {
   return useQuery(
-    "recent_tier_lists",
+    queryKeys.recentTierLists(),
     async () => await fetchRecentTierLists(),
     {
       onSuccess: (data) => console.log(data),

--- a/lib/queryKeys.ts
+++ b/lib/queryKeys.ts
@@ -1,0 +1,7 @@
+const RECENT_TIER_LISTS = "recent_tier_lists";
+
+export const queryKeys = {
+  recentTierLists() {
+    return [RECENT_TIER_LISTS];
+  },
+};


### PR DESCRIPTION
Replace magic string with a method call. Easier to keep track of query keys in the long term as we run into situations where we need to selectively invalidate/refetch data.

Ex: user publishes a new public tier list, so invalidate the cahced data of recent public tier lists